### PR TITLE
Add ???_with_tax by method_missint

### DIFF
--- a/lib/with_tax.rb
+++ b/lib/with_tax.rb
@@ -2,5 +2,17 @@ require "with_tax/version"
 
 module WithTax
   class Error < StandardError; end
-  # Your code goes here...
+
+  def method_missing(name, *args)
+    if name.match(/\A(.*)_with_tax\Z/)
+      self.class.class_eval do
+        define_method(name) do
+          (send($1) * 1.10).ceil
+        end
+      end
+      send(name)
+    else
+      super
+    end
+  end
 end

--- a/spec/with_tax_spec.rb
+++ b/spec/with_tax_spec.rb
@@ -1,9 +1,31 @@
 RSpec.describe WithTax do
-  it "has a version number" do
-    expect(WithTax::VERSION).not_to be nil
+  describe "WithTax::VERSION" do
+    it "has a version number" do
+      expect(WithTax::VERSION).not_to be nil
+    end
   end
 
-  it "does something useful" do
-    expect(true).to eq(true)
+  describe "#???_with_tax" do
+    context "SampleItem class exist" do
+      class SampleItem
+        include WithTax
+
+        attr_accessor :name, :price
+
+        def initialize(name, price)
+          @name = name
+          @price = price
+        end
+      end
+
+      describe "SampleItem#price_with_tax" do
+        subject { sample_item.price_with_tax }
+
+        let(:sample_item) { SampleItem.new("SampleName", price) }
+        let(:price) { rand(10000) + 1 }
+
+        it { is_expected.to eq (price * 1.10).ceil }
+      end
+    end
   end
 end


### PR DESCRIPTION
クラス定義中にincludeして…

```ruby
class SampleItem
  include WithTax

  attr_accessor :name, :price

  def initialize(name, price)
    @name = name
    @price = price
  end
end
```

`メソッド名_with_tax`とすると、税込みの金額が返されます。

```ruby
sample_item = SampleItem.new("鰹節削り5g 5+1パック", 158)
puts sample_item.price  # => 158
puts sample_item.price_with_tax # => 174
```
