### PR TITLE
Refactor

### DIFF
--- a/lib/with_tax.rb
+++ b/lib/with_tax.rb
@@ -5,14 +5,18 @@ module WithTax
 
   def method_missing(name, *args)
     if name.match(/\A(.*)_with_tax\Z/)
-      self.class.class_eval do
-        define_method(name) do
-          (send($1) * 1.10).ceil
-        end
-      end
+      add_with_tax_method(name)
       send(name)
     else
       super
+    end
+  end
+
+  def add_with_tax_method(name)
+    self.class.class_eval do
+      define_method(name) do
+        (send(name.to_s.delete_suffix("_with_tax")) * 1.10).ceil
+      end
     end
   end
 end

--- a/spec/with_tax_spec.rb
+++ b/spec/with_tax_spec.rb
@@ -1,31 +1,33 @@
 RSpec.describe WithTax do
+  before do
+    class SampleItem
+      include WithTax
+
+      attr_accessor :name, :price
+
+      def initialize(name, price)
+        @name = name
+        @price = price
+      end
+    end
+  end
+
+  after do
+    Object.instance_eval { remove_const :SampleItem }
+  end
+
   describe "WithTax::VERSION" do
     it "has a version number" do
       expect(WithTax::VERSION).not_to be nil
     end
   end
 
-  describe "#???_with_tax" do
-    context "SampleItem class exist" do
-      class SampleItem
-        include WithTax
+  describe "SampleItem#price_with_tax" do
+    subject { sample_item.price_with_tax }
 
-        attr_accessor :name, :price
+    let(:sample_item) { SampleItem.new("SampleName", price) }
+    let(:price) { rand(10000) + 1 }
 
-        def initialize(name, price)
-          @name = name
-          @price = price
-        end
-      end
-
-      describe "SampleItem#price_with_tax" do
-        subject { sample_item.price_with_tax }
-
-        let(:sample_item) { SampleItem.new("SampleName", price) }
-        let(:price) { rand(10000) + 1 }
-
-        it { is_expected.to eq (price * 1.10).ceil }
-      end
-    end
+    it { is_expected.to eq (price * 1.10).ceil }
   end
 end


### PR DESCRIPTION
- spec中で共通で使いそうになる `SampleItem`クラスの定義をbeforeで行うようにした。
- method_missingが大きかったので、(attr)_with_taxを定義する部分をメソッドに抽出した。