### PR TITLE
Add #rounding_method

### DIFF
--- a/lib/with_tax.rb
+++ b/lib/with_tax.rb
@@ -1,7 +1,11 @@
+require 'bigdecimal'
+require 'bigdecimal/util'
 require "with_tax/version"
 
 module WithTax
   class Error < StandardError; end
+
+  @_with_tax_rounding_method = :ceil
 
   def method_missing(name, *args)
     if name.match(/\A(.*)_with_tax\Z/)
@@ -15,8 +19,19 @@ module WithTax
   def add_with_tax_method(name)
     self.class.class_eval do
       define_method(name) do
-        (send(name.to_s.delete_suffix("_with_tax")) * 1.10).ceil
+        ret = send(name.to_s.delete_suffix("_with_tax")).to_s.to_d * 1.10
+
+        rounding_method = WithTax.rounding_method
+        rounding_method ? ret.send(rounding_method) : ret
       end
     end
+  end
+
+  def self.rounding_method=(strategy)
+    @_with_tax_rounding_method = strategy
+  end
+
+  def self.rounding_method
+    @_with_tax_rounding_method
   end
 end

--- a/spec/with_tax_spec.rb
+++ b/spec/with_tax_spec.rb
@@ -30,4 +30,74 @@ RSpec.describe WithTax do
 
     it { is_expected.to eq (price * 1.10).ceil }
   end
+
+  describe "#rounding_method" do
+    subject { sample_item.price_with_tax }
+
+    let(:sample_item) { SampleItem.new("SampleName", price) }
+
+    context "When rounding_method = nil" do
+      before { WithTax.rounding_method = nil }
+
+      context "When price = 123" do
+        let(:price) { 123 }
+
+        it { is_expected.to eq 135.3 }
+      end
+
+      context "When price = 345" do
+        let(:price) { 345 }
+
+        it { is_expected.to eq 379.5 }
+      end
+    end
+
+    context "When rounding_method = :floor" do
+      before { WithTax.rounding_method = :floor }
+
+      context "When price = 123" do
+        let(:price) { 123 }
+
+        it { is_expected.to eq 135 }
+      end
+
+      context "When price = 345" do
+        let(:price) { 345 }
+
+        it { is_expected.to eq 379 }
+      end
+    end
+
+    context "When rounding_method = :round" do
+      before { WithTax.rounding_method = :round }
+
+      context "When price = 123" do
+        let(:price) { 123 }
+
+        it { is_expected.to eq 135 }
+      end
+
+      context "When price = 345" do
+        let(:price) { 345 }
+
+        it { is_expected.to eq 380 }
+      end
+    end
+
+    context "When rounding_method = :ceil" do
+      before { WithTax.rounding_method = :ceil }
+
+      context "When price = 123" do
+        let(:price) { 123 }
+
+        it { is_expected.to eq 136 }
+      end
+
+      context "When price = 345" do
+        let(:price) { 345 }
+
+        it { is_expected.to eq 380 }
+      end
+    end
+  end
 end


### PR DESCRIPTION
小数点以下の処置方法を選べるようにした。

選べる種類は
- 何もしない nil
- 切り捨て :floor
- 四捨五入 :round
- 切り上げ :ceil