### PR TITLE
Add effective date

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ sample_item.price # => 123
 sample_item.price_with_tax #=> 136
 ```
 
+### 適用日
+
+税率改定があるときに、計算の基準になる日を指定することもできます。
+
+```ruby
+sample_item = SampleItem.new('Some item', 123)
+sample_item.price # => 123
+sample_item.price_with_tax(Date.parse('2019/09/30')) #=> 132
+```
+
 ### カスタマイズ
 
 #### 小数の取り扱い

--- a/lib/with_tax.rb
+++ b/lib/with_tax.rb
@@ -10,7 +10,7 @@ module WithTax
   def method_missing(name, *args)
     if name.match(/\A(.*)_with_tax\Z/)
       add_with_tax_method(name)
-      send(name)
+      send(name, *args)
     else
       super
     end
@@ -18,8 +18,9 @@ module WithTax
 
   def add_with_tax_method(name)
     self.class.class_eval do
-      define_method(name) do
-        ret = send(name.to_s.sub(/_with_tax\Z/, '')).to_s.to_d * (1 + WithTax::Rate.rate(nil, WithTax::Config.rate_type))
+      define_method(name) do |effective_date = nil|
+        mag = 1 + WithTax::Rate.rate(effective_date, WithTax::Config.rate_type)
+        ret = send(name.to_s.sub(/_with_tax\Z/, '')).to_s.to_d * mag
 
         rounding_method = WithTax::Config.rounding_method
         rounding_method ? ret.send(rounding_method) : ret

--- a/spec/with_tax_spec.rb
+++ b/spec/with_tax_spec.rb
@@ -44,6 +44,49 @@ RSpec.describe 'WithTax' do
     end
   end
 
+  describe '適用日の指定' do
+    subject { sample_item.price_with_tax(effective_date) }
+
+    let(:sample_item) { SampleItem.new('SampleName', price) }
+
+    before do
+      class SampleItem
+        include WithTax
+
+        attr_accessor :name, :price
+
+        def initialize(name, price)
+          @name = name
+          @price = price
+        end
+      end
+    end
+
+    after do
+      Object.instance_eval { remove_const :SampleItem }
+    end
+
+    context 'SampleItem#price = 123のとき' do
+      let(:price) { 123 }
+
+      context '適用日が2019/10/01(2019/10/01消費税改定後)のとき' do
+        let(:effective_date) { Date.parse('2019/10/01') }
+
+        it '136(10%)であること' do
+          expect(subject).to eql 136
+        end
+      end
+
+      context '適用日が2019/09/30(2019/10/01消費税改定前)のとき' do
+        let(:effective_date) { Date.parse('2019/09/30') }
+
+        it '133(8%)であること' do
+          expect(subject).to eql 133
+        end
+      end
+    end
+  end
+
   describe 'WithTax::Config.rounding_method=' do
     subject { sample_item.price_with_tax }
 


### PR DESCRIPTION
`attr_with_tax`に引数で適用日を指定できるようにし、任意の年月日での税込金額を求められるようにしました。