### PR TITLE
Use obj with tax rate type

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,36 @@ WithTax::Config.rate_type = :reduced
 sample_item.price_with_tax #=> 133
 ```
 
+##### 同一クラスで軽減税率対象かどうか変わる場合
+
+同一クラスで軽減税率対象かどうか変わる場合、`#with_tax_rate_type`で適切な値を返すようにすると、`attr_with_tax`がそれを元に計算します。
+
+```ruby
+class Food
+  include WithTax
+
+  attr_accessor :name, :price, :sales_type
+
+  def initialize(name, price, sales_type)
+    @name = name
+    @price = price
+    @sales_type = sales_type
+  end
+
+  def with_tax_rate_type
+    sales_type == :takeout ? :reduced : :default
+  end
+end
+
+curry = Food.new('カレー', 500, :in_store)
+curry.price #=> 500
+curry.price_with_tax #=> 550
+
+curry_takeout = Food.new('カレー(テイクアウト)', 500, :takeout)
+curry_takeout.price #=> 500
+curry_takeout.price_with_tax #=> 540
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/with_tax.rb
+++ b/lib/with_tax.rb
@@ -6,7 +6,7 @@ module WithTax
 
   def method_missing(name, *args)
     if name.match(/\A(.*)_with_tax\Z/)
-      WithTax::MethodDefiner.add_method(self.class, name)
+      WithTax::MethodDefiner.add_method(self, name)
       send(name, *args)
     else
       super

--- a/lib/with_tax/method_definer.rb
+++ b/lib/with_tax/method_definer.rb
@@ -5,10 +5,11 @@ require 'with_tax/config'
 
 module WithTax
   class MethodDefiner
-    def self.add_method(target_class, name)
-      target_class.class_eval do
+    def self.add_method(obj, name)
+      obj.class.class_eval do
         define_method(name) do |effective_date = nil|
-          mag = 1 + WithTax::Rate.rate(effective_date, WithTax::Config.rate_type)
+          rate_type = obj.respond_to?(:with_tax_rate_type) ? obj.with_tax_rate_type : WithTax::Config.rate_type
+          mag = 1 + WithTax::Rate.rate(effective_date, rate_type)
           ret = send(name.to_s.sub(/_with_tax\Z/, '')).to_s.to_d * mag
 
           rounding_method = WithTax::Config.rounding_method

--- a/spec/with_tax/method_definer_spec.rb
+++ b/spec/with_tax/method_definer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WithTax::MethodDefiner do
     end
 
     before do
-      WithTax::MethodDefiner.add_method(sample_item.class, :price_with_tax)
+      WithTax::MethodDefiner.add_method(sample_item, :price_with_tax)
     end
 
     it { is_expected.to respond_to(:price_with_tax).with(1).argument }

--- a/spec/with_tax_spec.rb
+++ b/spec/with_tax_spec.rb
@@ -212,4 +212,46 @@ RSpec.describe 'WithTax' do
       end
     end
   end
+
+  describe 'より詳細な税率種別の指定' do
+    subject { sample_item.price_with_tax }
+
+    let(:sample_item) { klass.new(123) }
+    let(:klass) do
+      Class.new do
+        include WithTax
+
+        attr_accessor :price
+
+        def initialize(price)
+          @price = price
+        end
+      end
+    end
+
+    before { Timecop.freeze(Date.parse('2019/10/01')) }
+    after { Timecop.return }
+
+    context 'with_tax_rate_typeが定義されているとき' do
+      before do
+        allow(sample_item).to receive(:with_tax_rate_type).and_return(rate_type)
+      end
+
+      context 'with_tax_rate_typeが:defaultを返すとき' do
+        let(:rate_type) { :default }
+
+        it '136(10%)であること' do
+          expect(subject).to eql 136
+        end
+      end
+
+      context 'with_tax_rate_typeが:reducedを返すとき' do
+        let(:rate_type) { :reduced }
+
+        it '136(10%)であること' do
+          expect(subject).to eql 133
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
WithTaxがincludeされたオブジェクトに
with_tax_rate_typeという属性やメソッドがあれば
それに基づいて税率を計算するようにしました。