### PR TITLE
Fix method_definer

### DIFF
--- a/lib/with_tax.rb
+++ b/lib/with_tax.rb
@@ -6,7 +6,7 @@ module WithTax
 
   def method_missing(name, *args)
     if name.match(/\A(.*)_with_tax\Z/)
-      WithTax::MethodDefiner.add_method(self, name)
+      WithTax::MethodDefiner.add_method(self.class, name)
       send(name, *args)
     else
       super

--- a/lib/with_tax/method_definer.rb
+++ b/lib/with_tax/method_definer.rb
@@ -5,10 +5,10 @@ require 'with_tax/config'
 
 module WithTax
   class MethodDefiner
-    def self.add_method(obj, name)
-      obj.class.class_eval do
+    def self.add_method(klass, name)
+      klass.class_eval do
         define_method(name) do |effective_date = nil|
-          rate_type = obj.respond_to?(:with_tax_rate_type) ? obj.with_tax_rate_type : WithTax::Config.rate_type
+          rate_type = respond_to?(:with_tax_rate_type) ? with_tax_rate_type : WithTax::Config.rate_type
           mag = 1 + WithTax::Rate.rate(effective_date, rate_type)
           ret = send(name.to_s.sub(/_with_tax\Z/, '')).to_s.to_d * mag
 

--- a/spec/with_tax/method_definer_spec.rb
+++ b/spec/with_tax/method_definer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WithTax::MethodDefiner do
     end
 
     before do
-      WithTax::MethodDefiner.add_method(sample_item, :price_with_tax)
+      WithTax::MethodDefiner.add_method(sample_item.class, :price_with_tax)
     end
 
     it { is_expected.to respond_to(:price_with_tax).with(1).argument }


### PR DESCRIPTION
add_methodをするときにインスタンスを引数に取るようにしていましたが、
クラスに変えました。
実行時に動的になく、事前にメソッドを追加しようとしたときに
扱いに困りそうだったからです。