### PR TITLE
Fix method_definer

### DIFF
--- a/lib/with_tax.rb
+++ b/lib/with_tax.rb
@@ -6,7 +6,8 @@ module WithTax
 
   def method_missing(name, *args)
     if name.match(/\A(.*)_with_tax\Z/)
-      WithTax::MethodDefiner.add_method(self.class, name)
+      attr_name = name.to_s.sub(/_with_tax\Z/, '')
+      WithTax::MethodDefiner.add_method(self.class, attr_name)
       send(name, *args)
     else
       super

--- a/lib/with_tax/method_definer.rb
+++ b/lib/with_tax/method_definer.rb
@@ -5,12 +5,13 @@ require 'with_tax/config'
 
 module WithTax
   class MethodDefiner
-    def self.add_method(klass, name)
+    def self.add_method(klass, attr_name)
       klass.class_eval do
-        define_method(name) do |effective_date = nil|
+        method_name = "#{attr_name}_with_tax"
+        define_method(method_name) do |effective_date = nil|
           rate_type = respond_to?(:with_tax_rate_type) ? with_tax_rate_type : WithTax::Config.rate_type
           mag = 1 + WithTax::Rate.rate(effective_date, rate_type)
-          ret = send(name.to_s.sub(/_with_tax\Z/, '')).to_s.to_d * mag
+          ret = send(attr_name).to_s.to_d * mag
 
           rounding_method = WithTax::Config.rounding_method
           rounding_method ? ret.send(rounding_method) : ret

--- a/spec/with_tax/method_definer_spec.rb
+++ b/spec/with_tax/method_definer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WithTax::MethodDefiner do
     end
 
     before do
-      WithTax::MethodDefiner.add_method(sample_item.class, :price_with_tax)
+      WithTax::MethodDefiner.add_method(sample_item.class, :price)
     end
 
     it { is_expected.to respond_to(:price_with_tax).with(1).argument }


### PR DESCRIPTION
method_missingから事前登録式に変えようとしていて、
そのときは属性名をベースにメソッドを追加するようにするほうが
やりやすいので、変更しました。